### PR TITLE
Reformat description lists to use style=nextline in package enumitem.

### DIFF
--- a/appendices.tex
+++ b/appendices.tex
@@ -247,7 +247,7 @@ LedgerSMB enforces these roles by allowing a user to select (list, read) data fr
 insert (create), update (edit) or delete (delete) data in the tables holding the data
 related to the execution of these tasks.
 
-\begin{description}
+\begin{description}[style=nextline]
 \item [account\_all] Allows the user to both create new and edit existing GL accounts.
 \item [account\_create] Allows the user to create (but not edit) new GL accounts.
 \item [account\_edit] Allows the user to edit (but not create) GL accounts.

--- a/master.tex
+++ b/master.tex
@@ -10,6 +10,9 @@
 \usepackage{longtable}
 \graphicspath{{images/}}
 
+% For use of next line in description list
+\usepackage{enumitem}
+
 % glossaries must be loaded *after* hyperref
 \usepackage[acronym]{glossaries}
 \makeglossaries

--- a/part-administration.tex
+++ b/part-administration.tex
@@ -230,7 +230,7 @@ three sections is entirely optional.
 
 Every part requires the following fields to be entered:
 
-\begin{itemize}
+\begin{description}[style=nextline]
 \item [Number] The (alphanumeric) code the company uses to identify the item
 \item [Description] The (native language) description of the item, used as the default
 	description on sales invoices
@@ -240,12 +240,12 @@ Every part requires the following fields to be entered:
 \item [COGS account] The P\&L (expense) Cost of Goods Sold (COGS) account to use
 	to post cost of sold items on
 \item [Sell price] The default selling price used on sales invoices
-\end{itemize}
+\end{description}
 
 
 The other fields in this section of the screen are optional:
 
-\begin{itemize}
+\begin{description}[style=nextline]
 \item [List price] Informational; can be used for any (monetary) purpose
 \item [Last cost] Last buying price, updated when a vendor invoice listing the current part
     is posted
@@ -258,7 +258,7 @@ The other fields in this section of the screen are optional:
 \item [ROP] Reorder point - when the inventory drops below this number,
      the part will show up in ``Short parts'' reports
 \item [Bin] The storage location in the warehouse
-\end{itemize}
+\end{description}
 
 
 Apart from these fields, there are also the Make and Model paired fields. Every part
@@ -291,13 +291,13 @@ as described in section
 This section of the screen lists one or more vendors from which the part can be
 purchased, with purchasing information for the given vendor:
 
-\begin{itemize}
+\begin{description}[style=nextline]
 \item [Vendor code] Code used by the vendor to identify the good, to be used by
     customizations and future enhancements (currently informational only)
 \item [Lead time] Lead time of the part from the vendor in days
 \item [Last cost] Last price at which the good was purchased from the vendor
 \item [Currency] The currency belonging to the Last cost field
-\end{itemize}
+\end{description}
 
 \subsubsection{Customer information}
 \label{subsubsec-parts-customer-information}
@@ -306,11 +306,11 @@ The customer information section specifies sell prices per customer or price gro
 where those are required to deviate from the default sell price. This mechanism exists
 to support the marketing principle of categorizing customers.
 
-\begin{itemize}
+\begin{description}[style=nextline]
 \item [Sell price] Price for this part to be used for this customer
 \item [From] Start of the applicability window of the price (inclusive)
 \item [To] End of the applicability window of the price (inclusive)
-\end{itemize}
+\end{description}
 
 \subsubsection{File attachments}
 \label{subsubsec-parts-file-attachments}
@@ -443,7 +443,7 @@ There are currently three types of summary accounts:
 \subsubsection{Receivables \& payables UI}
 \label{subsubsec-coa-AR-AP-checkmarks}
 
-\begin{itemize}
+\begin{description}[style=nextline]
 \item[Income (AR\_amount)] This check mark adds the account to the list of accounts
    in the transaction and invoice screens which are used to post income on.
 \item[Payment (AR\_paid)] This check mark adds the account to the list of accounts
@@ -455,7 +455,7 @@ There are currently three types of summary accounts:
    in \secref{sec-workflows-payment-processing-overpayments}.
 \item[Discount (AR\_discount)] Adds the account to the customer entry screen's selection
    list for accounts to post 
-\end{itemize}
+\end{description}
 
 The payables UI works the same way as the receivables UI. The difference is
 that the technical names of the configuration identifiers are prefixed by AP\_ instead
@@ -467,7 +467,7 @@ of AR\_.
 The items on this line relate to stocked items, i.e. those tracked for inventory: parts and
 assemblies.
 
-\begin{enumerate}
+\begin{description}[style=nextline]
 \item[Income (IC\_sale)] Adds the account to the selection list of income accounts on the
    part and assembly definition screens.
 \item[COGS (IC\_cogs)] Adds the account to the selection list of COGS @@@ accounts on the
@@ -475,7 +475,7 @@ assemblies.
 \item[Tax (IC\_taxpart)] Adds a check mark to the part and assembly definition screen
    for the applicable account. See \charef{cha-taxes} for more details on how taxes
    work in LedgerSMB.
-\end{enumerate}
+\end{description}
 
 @@@ Question: Labor/Overhead accounts == inventory accounts??
   % Labor/Overhead has an inventory and expense account but no income account.
@@ -486,19 +486,19 @@ assemblies.
 
 The items on this line relate to untracked (non stocked) items, i.e. services.
 
-\begin{enumerate}
+\begin{description}[style=nextline]
 \item[Income (IC\_income)] Adds the account to the income account selection list in
    the service definition screen.
 \item[Expense (IC\_expense)] Adds the account to the expense account selection list in
    the service definition screen.
 \item[Tax (IC\_taxservice)] Adds a check mark to the service definition screen for the
    applicable account. See \charef{cha-taxes} for more details on how taxes work in LedgerSMB.
-\end{enumerate}
+\end{description}
 
 \subsubsection{Fixed assets}
 \label{subsubsec-coa-fixed-assets}
 
-\begin{enumerate}
+\begin{description}[style=nextline]
 \item[Fixed asset (Fixed\_Asset)] Marks the account as holding the original asset value for the fixed
    assets module, for some classes of fixed assets.
 \item[Depreciation (Asset\_Dep)] Marks the account as holding the cumulative depreciation amount
@@ -507,7 +507,7 @@ The items on this line relate to untracked (non stocked) items, i.e. services.
    accounting module. See \secref{sec-workflows-accounting-fixed-asset-accounting} for more details.
 \item[Gain (asset\_gain)] Account to hold book value gain upon disposal of a fixed asset.
 \item[Loss (asset\_loss)] Account to hold book value loss upon disposal of a fixed asset.
-\end{enumerate}
+\end{description}
 
 
 \section{Alternative accounts (GIFI)}
@@ -575,7 +575,7 @@ the full history of the percentage rates, their dates of applicability and the t
 accounts they apply to. An account can show up any number of times, with different
 Valid To dates.
 
-\begin{description}
+\begin{description}[style=nextline]
 \item [Account name] The first column; not an input field
 \item [Rate (\%)] The rate to be applied to the sales amount
 \item [Min Taxable] The minimum amount for which the tax is applicable
@@ -673,7 +673,7 @@ Tax forms can be created (or edited) using the menu options available under the
 
 Tax forms have three fields.
 
-\begin{description}
+\begin{description}[style=nextline]
 \item [Country] Country to which the tax form applies
 \item [Description] Name of the tax form to be displayed in drop down lists
 \item [Select by Default] % ### TODO verify: Determines if the tax form check mark on invoices is checked  or unchecked by default

--- a/part-configuration.tex
+++ b/part-configuration.tex
@@ -59,7 +59,7 @@ Individual configuration keys; full discussion of possible values in reference a
 \label{subsubsec-global-config-ledgersmb-conf-general}
 
 
-\begin{description}
+\begin{description}[style=nextline]
 \item[auth]
 \item[logging]
 \item[tempdir] Directory to store temporary artifacts. E.g. PDF files are stored here before
@@ -139,7 +139,7 @@ Laser    = lpr -Plaser
 \subsubsection{'database' section}
 \label{subsubsec-global-config-ledgersmb-conf-database}
 
-\begin{description}
+\begin{description}[style=nextline]
 \item [host] Name of the host to connect to. See the documentation of the {\tt -h} command line option at 
    \url{http://www.postgresql.org/docs/9.2/static/app-psql.html}
    for more information (documentation unchanged since before 8.3, so applies to older versions as well)
@@ -278,7 +278,7 @@ LedgerSMB and the choices involved when being required to handle changes in tax 
 
 Each row lists the following fields:
 
-\begin{description}
+\begin{description}[style=nextline]
 \item [Rate (\%)] The tax rate to be applied when calculating VAT to be posted on this account.
 \item [Number] Account number
 \item [Valid To] The ending date of the settings in this row. This can apply to the rate as well as the ordering or the tax rules (but usually applies to the rate).
@@ -420,26 +420,25 @@ but they can also be prefixed numbers, e.g. INV0001 for invoices and EMP001 for 
 The numbers shown in the input boxes will be used to generate the next number in the
 numbering sequence.
 
-\begin{longtable}{ p{3.4cm} p{6.7cm} }
-GL Reference number & The default reference number for the next GL
-transaction. \\
-Sales invoice/ AR Transaction number & This number is used to generate an invoice
-number when none is being filled out by the user. \\
-Sales order number & Same as Sales invoice number, except that it's used for sales orders @@@ layout issue: the label is too big to fit on the page \\
-Vendor invoice/ AP Transaction number & Same as Sales invoice, except that the number
-is used for accounts payable transactions. @@@ layout issue: the label is too big to fit on the page \\
-Sales quotation number & Same as sales order number, except that it's used for quotations. \\
-RFQ number & Request for quotation number is like the sales quotation number, except
-that it is used to track which vendors have been asked for quotes. \\
-Part number & All parts, services and assemblies are identified by a unique number.
+\begin{description}[style=nextline]
+\item [GL Reference number] The default reference number for the next GL transaction.
+\item [Sales invoice/ AR Transaction number] This number is used to generate an invoice
+number when none is being filled out by the user.
+\item [Sales order number ] Same as Sales invoice number, except that it's used for sales orders @@@ layout issue: the label is too big to fit on the page
+\item [Vendor invoice/ AP Transaction number] Same as Sales invoice, except that the number
+is used for accounts payable transactions. @@@ layout issue: the label is too big to fit on the page 
+\item [Sales quotation number] Same as sales order number, except that it's used for quotations.
+\item [RFQ number] Request for quotation number is like the sales quotation number, except
+that it is used to track which vendors have been asked for quotes.
+\item [Part number] All parts, services and assemblies are identified by a unique number.
 When an item is created and no number is entered by the user, a number is generated
-from this sequence. \\
-Job/project number & Used when creating new projects. \\
-Employee number & Same as the sales invoice number, used by new employee entry. \\
-Customer number & @@@ is this the control code number? or is this
-meta\_number?? -- Meta-number (CT) \\
-Vendor number & @@@ same question as customer number \\
-\end{longtable}
+from this sequence.
+\item [Job/project number] Used when creating new projects.
+\item [Employee number ] Same as the sales invoice number, used by new employee entry.
+\item [Customer number] @@@ is this the control code number? or is this
+meta\_number?? -- Meta-number (CT) 
+\item [Vendor number] @@@ same question as customer number
+\end{description}
 
 \subsubsection{Check prefix}
 \label{subsubsec-company-config-defaults-check-prefix}

--- a/part-customization.tex
+++ b/part-customization.tex
@@ -32,7 +32,7 @@ single \gls{csv} file.
 The first line of the file contains the headers of the columns. The
 import routine expects the columns as presented in (table name).
 
-\begin{description}
+\begin{description}[style=nextline]
 \item [accno] Number of the account or header
 \item [desc] Description for the account or header
 \item [charttype] ``H'' for heading record, ``A'' for account record

--- a/part-workflows.tex
+++ b/part-workflows.tex
@@ -53,7 +53,7 @@ The procedure to create customers and vendors works exactly alike:
 
 A company has the following fields:
 
-\begin{description}
+\begin{description}[style=nextline]
 \item [Control code] Code to uniquely identify the company
 \item [Name] Legal name of the company
 \item [Country] Country of incorporation
@@ -77,7 +77,7 @@ accounts of that type can be added. The account entry screen lists the
 following fields\footnote{To simplify the interface if they're unused, some fields
 are not shown in case their selection lists are empty}:
 
-\begin{description}
+\begin{description}[style=nextline]
 \item [Customer number] Number to identify this account among all other accounts in the company;
      when left empty, the system will generate one when you click ``Save New''
 \item [Description] Textual representation of the account, usually a name
@@ -135,7 +135,7 @@ allows entry of prices could be considered a bug.
 
 The listing below describes the meaning of the per \gls{rfq} fields presented in the screen.
 
-\begin{description}
+\begin{description}[style=nextline]
 \item [Vendor (Customer)] Name of the company the quotation is requested from (issued to)
 \item [Currency] Currency for the intended transaction
 \item [Shipping point] Address to ship to ??? % ### TODO check with Chris
@@ -149,7 +149,7 @@ The listing below describes the meaning of the per \gls{rfq} fields presented in
 
 The following per item fields are listed.
 
-\begin{description}
+\begin{description}[style=nextline]
 \item [Item] Order number of the item
 \item [Number] Part number of the item to be ordered
 \item [Description] Description or name of the item to be ordered


### PR DESCRIPTION
This IMO improves the lists so that they don't intrude on the margins and starts the description in the same
column for each row in the list.  The list on page 81 was changed from a table to a list. This unifies lists in the workflow
section with lists at the beginning of the document.

Because of missing content, some pages are a little too sparse and look weird, but when the content is flushed out they will look better.