### PR TITLE
Standardize all images containing a menu to have width \linewidth.

### DIFF
--- a/part-administration.tex
+++ b/part-administration.tex
@@ -198,7 +198,7 @@ top level menu. See \figref{fig:user-preferences}.
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{user-preferences.png}
+\includegraphics[width=\linewidth]{user-preferences.png}
 \caption{User preferences screen}
 \label{fig:user-preferences}
 \end{figure}
@@ -625,7 +625,7 @@ have the specific account marked as relevant.
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{setup-tax-rates.png}
+\includegraphics[width=\linewidth]{setup-tax-rates.png}
 \caption{Tax account configuration screen}
 \end{figure}
 \label{fig:tax-account-config-screen}

--- a/part-configuration.tex
+++ b/part-configuration.tex
@@ -445,7 +445,7 @@ The template you want to change is selected in the "Template" drop-down. The tem
 
 \begin{figure}[h]
         \centering
-        \includegraphics[width=13cm]{system-templates.png}
+        \includegraphics[width=\linewidth]{system-templates.png}
         \caption{System templates screen}
         \label{fig:system-templates}
 \end{figure}
@@ -458,7 +458,7 @@ Select, for example, Template "Invoice" and Format "tex", you should see the vie
 
 \begin{figure}[h]
         \centering
-        \includegraphics[width=13cm]{system-templates-edit-invoice.png}
+        \includegraphics[width=\linewidth]{system-templates-edit-invoice.png}
         \caption{Templates edit invoice screen}
         \label{fig:system-templates-edit-invoice}
 \end{figure}

--- a/part-getting-started.tex
+++ b/part-getting-started.tex
@@ -338,7 +338,7 @@ After successful login, the system shows the Welcome to LedgerSMB  screen as dep
 \begin{figure}[h]
         \centering
         % \includegraphics[width=7cm]{welcome.png}
-        \includegraphics[width=\graphicswidth]{\autoscreenshotdir/welcome.png}
+        \includegraphics[width=\linewidth]{\autoscreenshotdir/welcome.png}
         \caption{login.pl welcome screen}
         \label{fig:login-welcome-screen}
 \end{figure}
@@ -400,7 +400,7 @@ as depicted in \figref{fig:user-preferences}
 \begin{figure}[H]
         \centering
         %\includegraphics[width=7cm]{user-preferences.png}
-        \includegraphics[width=\graphicswidth]{\autoscreenshotdir/preferences-preferences.png}
+        \includegraphics[width=\linewidth]{\autoscreenshotdir/preferences-preferences.png}
         \caption{User preferences}
         \label{fig:first-user-preferences}
 \end{figure}
@@ -416,7 +416,7 @@ In order to do so, Jack navigates to \menupath{System \ma Defaults} and sees the
 \begin{figure}[H]
         \centering
         % \includegraphics[width=7cm]{system-defaults.png}
-        \includegraphics[width=\graphicswidth]{\autoscreenshotdir/system--defaults.png}
+        \includegraphics[width=\linewidth]{\autoscreenshotdir/system--defaults.png}
         \caption{System defaults}
         \label{fig:first-user-system-defaults}
 \end{figure}
@@ -501,7 +501,7 @@ settings as configured for the sample checking account will do.
 \begin{figure}[h]
         \centering
 % \includegraphics[width=\linewidth]{setup-bank-account2.png}
-\includegraphics[width=11cm]{auto-screenshots/general-journal--chart-of-accounts.png}
+\includegraphics[width=\linewidth]{auto-screenshots/general-journal--chart-of-accounts.png}
 \caption{Bank account setup - account setup screen}
 \label{fig:bank-setup2}
 \end{figure}
@@ -621,7 +621,7 @@ To do so, he goes to the \menupath{ Goods and Services \ma Add part} page from t
 as shown in \figref{fig:setup-add-part}.
 
 \begin{figure}[h]
-        \includegraphics[width=\linewidth]{setup-add-part.png}
+\includegraphics[width=\linewidth]{setup-add-part.png}
         \caption{Add first part}
         \label{fig:setup-add-part}
 \end{figure}
@@ -701,7 +701,7 @@ button and adding the data as shown in \figref{fig:vendor-create-1}.
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{bus-vendor-create-2.png}
+\includegraphics[width=\linewidth]{bus-vendor-create-2.png}
 \caption{Company entry screen}
 \label{fig:vendor-create-1}
 \end{figure}
@@ -711,7 +711,7 @@ as shown in \figref{fig:vendor-create-2}.
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{bus-vendor-create-3.png}
+\includegraphics[width=\linewidth]{bus-vendor-create-3.png}
 \caption{Vendor account screen}
 \label{fig:vendor-create-2}
 \end{figure}
@@ -731,7 +731,7 @@ After which the page looks like \figref{fig:vendor-create-3}.
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{bus-vendor-create-4.png}
+\includegraphics[width=\linewidth]{bus-vendor-create-4.png}
 \caption{Vendor account screen - with purchase discount account}
 \label{fig:vendor-create-3}
 \end{figure}
@@ -753,7 +753,7 @@ in \figref{fig:rfq-entry-screen}) for entering a new \gls{rfq} .
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{rfq-entry-screen.png}
+\includegraphics[width=\linewidth]{rfq-entry-screen.png}
 \caption{RFQ entry screen}
 \label{fig:bus-rfq-entry-screen}
 \end{figure}
@@ -780,7 +780,7 @@ support to be correctly set up. The last selection list selects the language to 
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{rfq-email-screen.png}
+\includegraphics[width=\linewidth]{rfq-email-screen.png}
 \caption{RFQ e-mail screen}
 \label{fig:rfq-email-screen}
 \end{figure}
@@ -802,7 +802,7 @@ The screen shows additional buttons now that it shows a saved RFQ.
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{rfq-edit-screen.png}
+\includegraphics[width=\linewidth]{rfq-edit-screen.png}
 \caption{RFQ entry screen}
 \label{fig:bus-rfq-edit-screen}
 \end{figure}
@@ -836,7 +836,7 @@ be recorded until invoices have been posted.
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{order-receive-screen.png}
+\includegraphics[width=\linewidth]{order-receive-screen.png}
 \caption{Order receipt entry screen}
 \label{fig:order-receive-screen}
 \end{figure}

--- a/part-processes.tex
+++ b/part-processes.tex
@@ -132,7 +132,7 @@ Generally the only difference between creating a \gls{customer} account and a \g
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{rfq-entry-screen.png}
+\includegraphics[width=\linewidth]{rfq-entry-screen.png}
 \caption{RFQ entry screen}
 \label{fig:rfq-entry-screen}
 \end{figure}
@@ -265,7 +265,7 @@ saved and incomplete purchase order such as shown in
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{purchase-order-screen.png}
+\includegraphics[width=\linewidth]{purchase-order-screen.png}
 \caption{Saved purchase order}
 \label{fig:purchase-order-screen}
 \end{figure}
@@ -278,7 +278,7 @@ any orders which have items available for reception, see \figref{fig:shipping-re
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{shipping-receive-search-screen.png}
+\includegraphics[width=\linewidth]{shipping-receive-search-screen.png}
 \caption{Search screen for purchase order item receipts}
 \label{fig:shipping-receive-search-screen}
 \end{figure}
@@ -289,7 +289,7 @@ a listing of orders with matching the selection criteria as in \figref{fig:shipp
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{shipping-receive-search-result-screen.png}
+\includegraphics[width=\linewidth]{shipping-receive-search-result-screen.png}
 \caption{Search results screen for purchase order item receipts}
 \label{fig:shipping-receive-search-result-screen}
 \end{figure}
@@ -301,7 +301,7 @@ After confirmation of the receipt screen, items will be added to inventory.
 
 \begin{figure}[h]
 \centering
-\includegraphics[width=7cm]{shipping-receive-screen.png}
+\includegraphics[width=\linewidth]{shipping-receive-screen.png}
 \caption{Purchase order receipt screen}
 \label{fig:shipping-receive-screen}
 \end{figure}


### PR DESCRIPTION
The current images are largely unreadable when the text is readable. This should balance the scale better. There are a few exceptions for partial screen grabs.  There is still work to do on the image sizes, but after this change the work is largely in creating the images with the correct size, hopefully.