### PR TITLE
Add requirements for running gather-db-info.pl to development-notes.md

### DIFF
--- a/auto-generated/role_list_appendex.tex
+++ b/auto-generated/role_list_appendex.tex
@@ -1,4 +1,6 @@
-% Auto generated using LedgerSMB version 1.11.0-dev on July 15, 07:24:54 2023 CDT.
+
+Auto generated using LedgerSMB version 1.12.0-dev on November 21, 16:06:05 2023 CST.
+
 \begin{description}[style=nextline]
 \item [account\_all] \htmlspacing 
                          This role combines all \gls{GL} \index{GL}\index{General Ledger} account and GIFI code rights.

--- a/scripts/development-notes.md
+++ b/scripts/development-notes.md
@@ -25,8 +25,10 @@ sudo cpanm --notest LaTeXML
 sudo apt-get install -y latexmk
 
 # For `gather-db-info.pl`
+sudo apt-get install -y libdbi-perl libdbd-pg-perl 
 
 # For `get-screen-shots.pl`
+sudo apt-get install -y libtest-www-selenium-perl
 
 git clone https://github.com/neilt/ledgersmb-book.git
 				

--- a/scripts/gather-db-info.pl
+++ b/scripts/gather-db-info.pl
@@ -110,7 +110,7 @@ SQL
     # Accumulate the Latex to write to file.
     my $date = localtime->strftime('%B %e, %X %Y %Z');
     my $lsmb_version = get_lsmb_db_version($conn);
-    my @tex_array = "% Auto generated using LedgerSMB version ${lsmb_version} on $date.";
+    my @tex_array = "\nAuto generated using LedgerSMB version ${lsmb_version} on $date.\n";
     push (@tex_array, description_prolog());
 
     my $sth = $conn->prepare($sql);
@@ -137,7 +137,7 @@ SQL
 # Main
 #------------
 print "Example Usage:\n";
-print "  PGHOSTADDR='172.16.1.218' PGPORT='5001' PGDATABASE='jack' PGUSER='postgres' PGPASSWORD='abc' perl gather-db-info.pl\n";
+print "  PGHOSTADDR='172.16.1.218' PGPORT='5001' PGDATABASE='example_inc' PGUSER='postgres' PGPASSWORD='abc' perl gather-db-info.pl\n";
 
 # use environment variables for authentication
 # host         PGHOST                  local domain socket


### PR DESCRIPTION
Revise role_list_appendex.tex to make the update timestamp visible in the book. Previously it was in the LaTeX comments.