### PR TITLE
Fix graphviz dot files not building with LaTeXML

### DIFF
--- a/ledgersmb-book.tex
+++ b/ledgersmb-book.tex
@@ -65,11 +65,20 @@
 \newcommand{\graphicswidth}{0.8\textwidth}
 \newcommand{\autoscreenshotdir}{auto-screenshots}
 
+% Required to allow LaTeXML to handle graphviz
+\usepackage{ifpdf}
+
 % For use of next line in description list
 \usepackage{enumitem}
 \setlist[description]{style=nextline}
 
+\ifpdf
+% LaTeXML does not work with graphviz
+% So we have to workaround that by only generating dot files when producing
+% pdf files.  The dot files are in the repository and if they need to be regenerated
+% then they need to be deleted and regnerated by producing a new book pdf.
 \usepackage[pdf]{graphviz}
+\fi
 
 % For fixing the postition of figures using H
 \usepackage{float}

--- a/part-customization.tex
+++ b/part-customization.tex
@@ -59,29 +59,41 @@ if the \texttt{Post} action is executed on a \texttt{saved} invoice, its new sta
 will be \texttt{posted}.  E-mailing an invoice does not change its state: it
 remains posted.  Instead, a new workflow is created which manages state of the e-mail.
 
-\begin{figure}
-\digraph[scale=0.4]{wf1}{
-	rankdir=LR;
-	subgraph invoice {
-		graph [label="Invoice"];
-		cluster = true;
-		saved -> posted [label="post"];
-		posted -> reversed [label="reverse"];
-	};
-
-    subgraph email {
-    	graph [label="email"];
-    	cluster = true;
-    	created -> sent [label="send"];
-    };
-
-    posted -> created [label="e-mail"];
-    posted -> posted [label="e-mail"];
-
+ \IfFileExists{./wf1.pdf}{
+ 	\begin{figure}[H]
+		\centering
+		% \includegraphics[width=0.8\textwidth]{dmc-create-step1.png}
+		% HTML processing does not handle cropping of this image, need to figure out why?
+		% \includegraphics[width=\graphicswidth,  trim={0pt 50 0 0}, clip]{\autoscreenshotdir/setup-pl-login.png}
+		\includegraphics[width=\graphicswidth]{wf1.pdf}
+		\caption{Workflow triggered from another workflow}
+		\label{fig:triggered-workflow}
+	\end{figure}
+}{
+	\begin{figure}
+	\digraph[scale=0.4]{wf1}{
+		rankdir=LR;
+		subgraph invoice {
+			graph [label="Invoice"];
+			cluster = true;
+			saved -> posted [label="post"];
+			posted -> reversed [label="reverse"];
+		};
+	
+	    subgraph email {
+	    	graph [label="email"];
+	    	cluster = true;
+	    	created -> sent [label="send"];
+	    };
+	
+	    posted -> created [label="e-mail"];
+	    posted -> posted [label="e-mail"];
+	
+	}
+	\caption{Workflow triggered from another workflow}
+	\label{fig:triggered-workflow}
+	\end{figure}
 }
-\caption{Workflow triggered from another workflow}
-\label{fig:triggered-workflow}
-\end{figure}
 
 Actions belonging to a state may (or may not) be available. This is determined by one or
 more conditions.  Examples are ``is the posting date of the transaction in a closed period''
@@ -103,21 +115,33 @@ and action in the invoice, an extra reviewing pairs of eyes can be added to the 
 By adding a condition on this action, it can be made required for invoices over 100.000 USD
 (but not for other invoices).
 
-\begin{figure}
-\digraph[scale=0.4]{wf2}{
-	rankdir=LR;
-	subgraph invoice {
-		graph [label="Invoice"];
-		cluster=true;
-		saved -> posted [label="post (<100.000)"];
-		saved -> submitted [label="submit (>100.000)"];
-		submitted -> posted [label="post"];
-		posted -> reversed [label="reverse"]
-	}
+\IfFileExists{./wf2.pdf}{
+	\begin{figure}[H]
+		\centering
+		% \includegraphics[width=0.8\textwidth]{dmc-create-step1.png}
+		% HTML processing does not handle cropping of this image, need to figure out why?
+		% \includegraphics[width=\graphicswidth,  trim={0pt 50 0 0}, clip]{\autoscreenshotdir/setup-pl-login.png}
+		\includegraphics[width=\graphicswidth]{wf2.pdf}
+		\caption{Conditional workflow actions}
+		\label{fig:conditional-workflows}
+	\end{figure}
+}{
+	\begin{figure}
+		\digraph[scale=0.4]{wf2}{
+			rankdir=LR;
+			subgraph invoice {
+				graph [label="Invoice"];
+				cluster=true;
+				saved -> posted [label="post (<100.000)"];
+				saved -> submitted [label="submit (>100.000)"];
+				submitted -> posted [label="post"];
+				posted -> reversed [label="reverse"]
+			}
+		}
+		\caption{Conditional workflow actions}
+		\label{fig:conditional-workflows}
+	\end{figure}
 }
-\caption{Conditional workflow actions}
-\label{fig:conditional-workflows}
-\end{figure}
 
 By changing association of the \texttt{save} action with its code, the application will act
 differently when saving the invoice.  Customizations may associate new behaviors with existing

--- a/wf1.dot
+++ b/wf1.dot
@@ -1,0 +1,19 @@
+digraph wf1 {
+rankdir=LR;
+subgraph invoice {
+graph [label="Invoice"];
+cluster = true;
+saved -> posted [label="post"];
+posted -> reversed [label="reverse"];
+};
+
+subgraph email {
+graph [label="email"];
+cluster = true;
+created -> sent [label="send"];
+};
+
+posted -> created [label="e-mail"];
+posted -> posted [label="e-mail"];
+
+}

--- a/wf2.dot
+++ b/wf2.dot
@@ -1,0 +1,11 @@
+digraph wf2 {
+rankdir=LR;
+subgraph invoice {
+graph [label="Invoice"];
+cluster=true;
+saved -> posted [label="post (<100.000)"];
+saved -> submitted [label="submit (>100.000)"];
+submitted -> posted [label="post"];
+posted -> reversed [label="reverse"]
+}
+}


### PR DESCRIPTION
This commit works around the fact that LaTeXML does not handle graphviz.  So we create the dot files when generating the pdf, then while processing LaTeXML we only include the graphic images.  

The downside of this fix is that whenever the dot files change, the book PDF must be generated before the LaTeXML processing.  I think this happens automatically, but if the output does not change then both wf1 and wf2 files with both extensions .pdf and .dot may need to be deleted and regenerated.  

Fixes the following errors in HTML generated files.

<img width="812" alt="Screenshot 2024-11-22 at 3 11 05 PM" src="https://github.com/user-attachments/assets/4e1b14a4-0c28-4cdb-b955-5f3af9816e8f">

<img width="826" alt="Screenshot 2024-11-22 at 3 10 56 PM" src="https://github.com/user-attachments/assets/bfc20681-552b-4329-b4b4-a3a0c8c7510c">
